### PR TITLE
update badge address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # resumeanalyser
 
-[![Documentation Status](https://readthedocs.org/projects/resume-analyser/badge/?version=latest)](https://resume-analyser.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/resume-analyser/badge/?version=latest)](https://resume-analyser.readthedocs.io/en/latest)
 
 The ResumeAnalyser package is a comprehensive toolkit designed for automated and efficient parsing, analysis, and evaluation of resumes. Leveraging advanced algorithms, it extracts key information like educational background, professional experience, skills, and certifications from a variety of resume formats. This package also includes features for ranking candidates based on customizable criteria, making it an indispensable tool for HR professionals and recruiters seeking to streamline the hiring process. Its intuitive API and compatibility with multiple programming languages ensure easy integration into existing HR systems, significantly enhancing recruitment workflows.
 


### PR DESCRIPTION
The old badge address: https://resume-analyser.readthedocs.io/en/latest/?badge=latest
is not updated together with the latest version, I changed it to a new address that will always be updated automatically:
https://resume-analyser.readthedocs.io/en/latest